### PR TITLE
Inputfix

### DIFF
--- a/modules/align.nf
+++ b/modules/align.nf
@@ -1,4 +1,7 @@
 process alignment{
+  
+  containerOptions "-v \$(dirname ${params.genomeIdx}):\$(dirname ${params.genomeIdx})"
+  
   label 'bigCPU'
   memory { params.genomeSize > 200000000 ? params.high_memory : params.low_memory}
   publishDir "${params.outDir}/QC/02_ALIGNMENT", mode: 'copy', pattern: "*_alignment_stats.txt"

--- a/modules/alignmentsieve.nf
+++ b/modules/alignmentsieve.nf
@@ -1,4 +1,7 @@
 process sieve_mono{
+  if(params.blacklist){
+  containerOptions "-v \$(dirname ${params.blacklist}):\$(dirname ${params.blacklist})"
+  }
   label 'big'
   publishDir "${params.outDir}/QC/05_ALIGNMENT_FILTERING/monoNuc", mode: 'copy', pattern: "*_mono_FiltLog.txt"
   publishDir "${params.outDir}/RUN/00_ALIGNMENT/monoNuc", mode: 'copy', pattern: "*_mono.bam", enabled:params.publishBamFlt
@@ -24,6 +27,9 @@ process sieve_mono{
 }
 
 process sieve_sub{
+  if(params.blacklist){
+  containerOptions "-v \$(dirname ${params.blacklist}):\$(dirname ${params.blacklist})"
+  }
   label 'big'
   publishDir "${params.outDir}/QC/05_ALIGNMENT_FILTERING/subNuc", mode: 'copy', pattern: "*_sub_FiltLog.txt"
   publishDir "${params.outDir}/RUN/00_ALIGNMENT/subNuc", mode: 'copy', pattern: "*_sub.bam", enabled:params.publishBamFlt

--- a/modules/get_TSS_profile.nf
+++ b/modules/get_TSS_profile.nf
@@ -1,4 +1,6 @@
 process TSS_profile_mono{
+  containerOptions "-v \$(dirname ${params.TSS}):\$(dirname ${params.TSS})"
+  
   label 'mid'
 
   input:
@@ -38,6 +40,7 @@ process TSS_profile_plot_mono{
 }
 
 process TSS_profile_sub{
+  containerOptions "-v \$(dirname ${params.TSS}):\$(dirname ${params.TSS})"
   label 'mid'
 
   input:


### PR DESCRIPTION
Docker is now able to mount annotation folders even if not located on the same Volume as long as Docker has permission to acess these.